### PR TITLE
Fixed yaml to make node-anazlyer (image scanner) work

### DIFF
--- a/blueprints/getting-started/values.yaml
+++ b/blueprints/getting-started/values.yaml
@@ -11,6 +11,6 @@ agent:
 nodeAnalyzer:
   nodeAnalyzer:
     apiEndpoint: ${sysdigNodeAnalyzer} # secure.sysdig.com for sysdig us1
-    secure:
-      vulnerabilityManagement:
-        newEngineOnly: true
+  secure:
+    vulnerabilityManagement:
+      newEngineOnly: true


### PR DESCRIPTION
Fixed yaml to make node-anazlyer (image scanner) work

secure.vulnerabilityManagement.newEngineOnly: true